### PR TITLE
fix(ox_core): move GetGroup to common

### DIFF
--- a/types/ox_core/common.lua
+++ b/types/ox_core/common.lua
@@ -6,6 +6,11 @@
 Ox = {}
 
 ---**`common`**
+---@param name string
+---@return OxGroup
+function Ox.GetGroup(name) end
+
+---**`common`**
 ---@param groupName string
 ---@return OxGroupPermissions
 function Ox.GetGroupPermissions(groupName) end
@@ -88,7 +93,7 @@ local VehicleClasses = {
 ---@field type VehicleTypes;
 ---@field weapons? true;
 
----@alias OxAccountRole  'viewer' | 'contributor' | 'manager' | 'owner'
+---@alias OxAccountRole 'viewer' | 'contributor' | 'manager' | 'owner'
 
 ---@class OxAccount
 ---@field id number
@@ -102,10 +107,12 @@ local VehicleClasses = {
 ---@class OxGroup
 ---@field name string
 ---@field label string
----@field grades {label: string, accountRole: OxAccountRole}[]
+---@field grades string[]
+---@field accountRoles table<string, OxAccountRole>
 ---@field type string?
 ---@field colour number?
 ---@field hasAccount boolean
+---@field principal string?
 
 ---@class OxPlayer
 ---@field public userId number

--- a/types/ox_core/server_ox.lua
+++ b/types/ox_core/server_ox.lua
@@ -1,5 +1,13 @@
 ---@meta
 
+---@class OxCreateGroupProperties
+---@field name string
+---@field label string
+---@field grades {label: string, accountRole?: OxAccountRole}[]
+---@field type string?
+---@field colour number?
+---@field hasAccount boolean?
+
 ---@class OxServer
 Ox = {}
 
@@ -10,7 +18,7 @@ Ox = {}
 function Ox.CreateAccount(ownerId, label) end
 
 ---**`server`**
----@param data OxGroup
+---@param data OxCreateGroupProperties
 function Ox.CreateGroup(data) end
 
 ---**`server`**
@@ -62,11 +70,6 @@ function Ox.GetGroupAccount(groupName) end
 ---@param groupType string
 ---@return string[]
 function Ox.GetGroupsByType(groupType) end
-
----**`server`**
----@param name string
----@return OxGroup
-function Ox.GetGroup(name) end
 
 ---**`server`**
 ---@param playerId number


### PR DESCRIPTION
- Moved `Ox.GetGroup` to common types
- Created new type `OxCreateGroupProperties` for `Ox.CreateGroup` `data` param, since it differs from the `OxGroup` type.