### PR TITLE
fix(ox_core/server): use correct type for GetVehicle handle param

### DIFF
--- a/types/ox_core/server_ox.lua
+++ b/types/ox_core/server_ox.lua
@@ -97,9 +97,9 @@ function Ox.GetPlayerFromCharId(charId) end
 function Ox.GetPlayers(filter) end
 
 ---**`server`**
----@param entityId number
+---@param handle string|number `vin` or `entityId`
 ---@return OxVehicleServer
-function Ox.GetVehicle(entityId) end
+function Ox.GetVehicle(handle) end
 
 ---**`server`**
 ---@param entityId number


### PR DESCRIPTION
This PR changes the param type for `Ox.GetVehicle` to align with the changes from https://github.com/CommunityOx/ox_core/pull/6.